### PR TITLE
Ignore SocketTimeoutException when reading connection responses first time

### DIFF
--- a/src/main/java/com/spotifyxp/deps/xyz/gianlu/librespot/core/Session.java
+++ b/src/main/java/com/spotifyxp/deps/xyz/gianlu/librespot/core/Session.java
@@ -331,6 +331,7 @@ public class Session implements Closeable {
                 } else if (read > 0) {
                     throw new IllegalStateException("Read unknown data!");
                 }
+            } catch (SocketTimeoutException ignored) {
             } finally {
                 conn.socket.setSoTimeout(0);
             }


### PR DESCRIPTION
Handle it only if the first connection request has failed. This avoids endless exception with reconnecting when connecting SpotifyXP with already logined account. However LoginDialog still crashes. This imports a part of the latest librespot-java code from https://github.com/librespot-org/librespot-java/blob/d0ff31b4f476590c9c17401aac01a6762e4ba908/lib/src/main/java/xyz/gianlu/librespot/core/Session.java#L321.
Fixes #44 .
Here are some screenshots proving SpotifyXP now starts properly on several OSes (despite LoginDialog):
Ubuntu 21.10:
![Снимок экрана от 2024-07-19 21-07-50](https://github.com/user-attachments/assets/27e11e3a-c2db-4b1f-9e1e-9082e950391a)
ReactOS 0.4.15-dev:
![SpotifyXP_ROS](https://github.com/user-attachments/assets/7a55cca0-677c-45f5-b567-75a4a3be7371)
Windows XP Professional SP3:
![VirtualBox_Windows XP_19_07_2024_21_16_36](https://github.com/user-attachments/assets/755072e7-e635-4870-8831-d902c4342fc1)