### PR TITLE
Add missing UI elements initialization for LoginDialog

### DIFF
--- a/src/main/java/com/spotifyxp/dialogs/LoginDialog.java
+++ b/src/main/java/com/spotifyxp/dialogs/LoginDialog.java
@@ -28,13 +28,28 @@ public class LoginDialog extends JDialog {
 
     public LoginDialog() {
 
+        contentPane = new JPanel();
+        setContentPane(contentPane);
+        setModal(true);
+        setPreferredSize(new Dimension(350, 356));
+        setResizable(false);
+
+        spotifyusernamefield = new CustomLengthTextField(254); //https://stackoverflow.com/questions/386294/what-is-the-maximum-length-of-a-valid-email-address
+        spotifyusernamefield.setBounds(10, 81, 314, 39);
         spotifyusernamefield.setColumns(10);
+        add(spotifyusernamefield);
 
+        usernamepasswordfield = new CustomLengthPasswordField(500); //https://community.spotify.com/t5/Accounts/max-password-lenght/td-p/5533953
         usernamepasswordfield.setColumns(10);
+        usernamepasswordfield.setBounds(10, 179, 314, 39);
+        add(usernamepasswordfield);
 
+        facebook = new JButton();
         facebook.setText("Facebook");
+        facebook.setBounds(10, 228, 314, 20);
         facebook.setEnabled(false);
         facebook.setToolTipText("Facebook auth not supported"); //https://github.com/SpotifyXP/SpotifyXP/issues/15
+        //add(facebook);
         facebook.addActionListener(new AsyncActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
@@ -46,7 +61,12 @@ public class LoginDialog extends JDialog {
             }
         }));
 
+        getRootPane().setDefaultButton(spotifyokbutton);
+
+        spotifyokbutton = new JButton();
         spotifyokbutton.setText("Ok"); //ToDo: Translate
+        spotifyokbutton.setBounds(10, 275, 139, 31);
+        add(spotifyokbutton);
         spotifyokbutton.addActionListener(new AsyncActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
@@ -57,7 +77,10 @@ public class LoginDialog extends JDialog {
             }
         }));
 
+        spotifycancelbutton = new JButton();
         spotifycancelbutton.setText("Cancel"); //ToDo: Translate
+        spotifycancelbutton.setBounds(185, 275, 139, 31);
+        add(spotifycancelbutton);
         spotifycancelbutton.addActionListener(new AsyncActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
@@ -65,17 +88,18 @@ public class LoginDialog extends JDialog {
             }
         }));
 
+        spotifylabelusername = new JLabel();
         spotifylabelusername.setText("E-Mail"); //ToDo: Translate
+        spotifylabelusername.setBounds(10, 60, 111, 14);
+        add(spotifylabelusername);
 
+        spotifylabelpassword = new JLabel();
         spotifylabelpassword.setText("Password"); //ToDo: Translate
+        spotifylabelpassword.setBounds(10, 158, 111, 14);
+        add(spotifylabelpassword);
     }
 
     public void openWithInvalidAuth() {
-        setContentPane(contentPane);
-        setModal(true);
-        setPreferredSize(new Dimension(350, 356));
-        setResizable(false);
-        getRootPane().setDefaultButton(spotifyokbutton);
         setTitle("Invalid Login! Try again"); //ToDo: Translate
         getRootPane().putClientProperty("JRootPane.titleBarForeground", Color.red);
         Initiator.past = true;
@@ -89,11 +113,6 @@ public class LoginDialog extends JDialog {
     }
 
     public void open() {
-        setContentPane(contentPane);
-        setModal(true);
-        setPreferredSize(new Dimension(350, 356));
-        setResizable(false);
-        getRootPane().setDefaultButton(spotifyokbutton);
         setTitle("Enter Spotify Credentials"); //ToDo: Translate
         Initiator.past = true;
         SplashPanel.frame.setAlwaysOnTop(false);
@@ -108,10 +127,5 @@ public class LoginDialog extends JDialog {
     public static void main(String[] args) {
         LoginDialog dialog = new LoginDialog();
         dialog.open();
-    }
-
-    private void createUIComponents() {
-        spotifyusernamefield = new CustomLengthTextField(254); //https://stackoverflow.com/questions/386294/what-is-the-maximum-length-of-a-valid-email-address
-        usernamepasswordfield = new CustomLengthPasswordField(500); //https://community.spotify.com/t5/Accounts/max-password-lenght/td-p/5533953
     }
 }


### PR DESCRIPTION
Restore an initialization of several UI elements which was previously removed. Move some initialization code to the dialog creation constructor.
Fixes LoginDialog crash when trying to login in Spotify account.
Properly fixes #43.
Here are some screenshots proving LoginDialog does not crash anymore and works perfectly now, although it looks a bit crooked, judging by the elements position (works on all OSes):
Ubuntu 21.10:
![Снимок экрана от 2024-07-19 21-09-18](https://github.com/user-attachments/assets/d6e12666-6d47-49e2-83a7-b71253e904ab)
Windows XP Professional SP3:
![VirtualBox_Windows XP_19_07_2024_21_15_38](https://github.com/user-attachments/assets/fab38215-792b-4e07-babb-66aa7c2b365c)
I did not make a screenshot yet, but it works in ReactOS 0.4.15-dev as well too. :slightly_smiling_face: 
On ReactOS and Windows XP, I tested it with the following Java version: https://archive.org/details/jre1.8.0_251_XP. Much older versions (e. g., 8u51, are not working properly with this still).