### PR TITLE
Remove "Free accounts are not supported" notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@
 
 ![Contributors](https://img.shields.io/github/contributors/NTifyApp/NTify?color=dark-green) ![Issues](https://img.shields.io/github/issues/NTifyApp/NTify) ![Downloads](https://img.shields.io/github/downloads/NTifyApp/NTify/total)
 
-<h3>Info: Free accounts are not supported
-
 ## Table Of Contents
 
 * [About the Project](#about-the-project)
@@ -100,8 +98,8 @@ See **New Login Methods*.
 Then, enjoy streaming.
 
 ## New login methods
-1. Zeroconf: In a modern Spotify client, choose NTify under devices to authenticate.
-2. OAuth: Log into Spotify in the auto-opened browser window, confirm NTify connection, then close it. (needs a HTML5 supported browser)
+1. Zeroconf: In a modern Spotify client, choose NTify under devices to authenticate. Works only with Premium accounts.
+2. OAuth: Log into Spotify in the auto-opened browser window, confirm NTify connection, then close it. (needs a HTML5 supported browser) Works with Free accounts as well.
 
 ## Compiling
 


### PR DESCRIPTION
That's not actually true, because I'm still able to login and listen with my Spotify Free account using the latest development build of NTify (via OAuth login method). I did the clear login if what. Screenshot is attached as well.
Tested on Ubuntu 21.10 + OpenJDK 18, but it should work the same on Windows XP SP3 + Java 8 Update 151 too (since it depends on NTify itself, not on currently used Java/OpenJDK version).
Premium is required only for Zeroconf login method, but not for OAuth one.
So let's not confuse users with wrong information.
Additionally, add some more info about Free/Premium accounts support into Login methods info.
![ntify](https://github.com/user-attachments/assets/715dd5ff-fa8e-4425-860e-3d96b2ececa2)